### PR TITLE
Disable ajax.update button only if it's not a confirm.

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -121,7 +121,9 @@ $(function () {
         var confirm = $button.attr('data-confirm');
 
         //To prevent multisending
-        $button.prop('disabled', true);
+        if (!confirm) {
+            $button.prop('disabled', true);
+        }
 
         function handle() {
             if (csrftoken) {


### PR DESCRIPTION
If we have a confirm, user could click on Cancel, in this case button stays disabled.
